### PR TITLE
Fix path for 404 error file

### DIFF
--- a/.cloud/nginx/nginx.conf
+++ b/.cloud/nginx/nginx.conf
@@ -3,5 +3,5 @@ server {
   index index.php index.html index.htm;
   root /var/www/public/;
 
-  error_page 401 403 404 429 /404.html;
+  error_page 401 403 404 429 ./404.html;
 }


### PR DESCRIPTION
### Motivation

Error 404 is not well configured in nginx because /404.html doesn't exist which result in 403 error.

I suggest to fix the path of the 404 error file.

Thanks