### PR TITLE
Fix 404 redirect

### DIFF
--- a/.cloud/nginx/nginx.conf
+++ b/.cloud/nginx/nginx.conf
@@ -3,5 +3,6 @@ server {
   index index.php index.html index.htm;
   root /var/www/public/;
 
-  error_page 401 403 404 429 ./404.html;
+  try_files $uri =404;
+  error_page 401 403 404 429 /404.html;
 }


### PR DESCRIPTION
Currently, when a 4xx error occurs, the relative path `./404.html` used in
the `error_page` directive causes Nginx to issue a 302 redirect to
`404.html`. Unfortunately, this relative path also causes an infinite
redirect loop if there are path segments in the URL, for example as
`/foo/` redirects to `/foo/./404.html`, which again does not exist and
redirects to itself.

This change instead causes Nginx to issue a 404 error if the `$uri`
cannot be found and to handle that error with an invisible internal
redirect to the 404 error page so that no user-facing redirect occurs
and the user's address bar remains unchanged.

It looks like this was introduced in #11 while attempting to fix another
issue, but I believe this fixes both without causing any regression.

Please let me know if this needs any further clarification or work to
merge. Thanks for taking the time to publish this image!

References:
https://nginx.org/en/docs/http/ngx_http_core_module.html#error_page
https://nginx.org/en/docs/http/ngx_http_core_module.html#try_files