### PR TITLE
Add an alternative project link to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # ⚠️ DEPRECATION WARNING ⚠️
 
-I'm not using this image anymore. I switched from Traefik to [Caddy](https://caddyserver.com) because Traefik is far too complicated for **my** needs. This image works as it. If you want new features, feel free to fork the project. 
+I'm not using this image anymore. I switched from Traefik to [Caddy](https://caddyserver.com) because Traefik is far too complicated for **my** needs. This image works as it. If you want new features, feel free to fork the project. An alternative project for the traefik error pages is [tarampampam/error-pages](https://github.com/tarampampam/error-pages).
 
 # Custom error pages for Traefik
 


### PR DESCRIPTION
Hi @guillaumebriday!

I have made an alternative project for the traefik error pages, and this PR adds a link to it. Thank you in advance for accepting it.